### PR TITLE
Refactoring use of `self.subgraphs` attribute

### DIFF
--- a/rxnpath/core.py
+++ b/rxnpath/core.py
@@ -115,7 +115,8 @@ class ReactionDiagram(nx.DiGraph):
             'new_node' to both 'C' and 'E' in the order: C -> new_node -> E.
             If `None`, then no edges will be added.
         color : str, optional
-            Name of the color for the new state.
+            Color for the new state. Any edges connected to this state will
+            also have this color.
         """
         if edges:
             for (u, v) in edges:

--- a/rxnpath/core.py
+++ b/rxnpath/core.py
@@ -147,7 +147,8 @@ class ReactionDiagram(nx.DiGraph):
 
         if pathname in self.pathways.keys():
             # Build list of new subgraph.
-            new_sg = list(self.pathways[pathname].nodes()).append(label)
+            new_sg = list(self.pathways[pathname].nodes())
+            new_sg.append(label)
         else:
             new_sg = [label]
         # Assign subgraphs dictionary with updated subgraph.

--- a/rxnpath/core.py
+++ b/rxnpath/core.py
@@ -11,19 +11,20 @@ class ReactionDiagram(nx.DiGraph):
     def __init__(self, colors=['black', 'blue', 'green',
                                'red', 'purple', 'orange'], **kwargs):
         nx.DiGraph.__init__(self, **kwargs)
-        self.subgraphs = {}
+        self.pathways = {}
         self._step_size = None
         self._colors = colors.copy()
         return
 
-    def add_pathway(self, labels, energies, pathname, color=None, positions=[]):
+    def add_pathway(self, labels, energies, pathname,
+                    color=None, positions=[]):
         """
         Adds a reaction pathway to reaction diagram.
 
-        Generates a subgraph labeled as `name`. Can be accessed with
-        self.subgraphs[`name`]. Necessary data are stored in each node/
-        edge of the graph, such as labels, energies, positions, and
-        color for each node in the subgraph.
+        Generates a pathway labeled as `name`. Can be accessed with
+        self.pathways[`name`]. Necessary data are stored in each node/
+        edge of the graph, such as energies, positions, and color for
+        each node in the pathway.
 
         Parameters
         ----------
@@ -86,7 +87,7 @@ class ReactionDiagram(nx.DiGraph):
 
         self.add_nodes_from(labels, color=color)
         self.add_path(labels, color=color)
-        self.subgraphs[name] = self.subgraph(labels)
+        self.pathways[pathname] = self.subgraph(labels)
 
         for i, label in enumerate(labels):
             self.node[label]['position'] = positions[label]
@@ -122,13 +123,15 @@ class ReactionDiagram(nx.DiGraph):
                     "'{}' not included in the edge declaration.".format(label)
                 if u == label:
                     # Check if label already exists in graph.
-                    assert not self.has_node(u), "'{}' already exists".format(u)
+                    assert not self.has_node(u),\
+                        "'{}' already exists".format(u)
                 else:
                     assert self.has_node(u), "'{}' does not exist".format(u)
 
                 if v == label:
                     # Check if label already exists in graph.
-                    assert not self.has_node(v), "'{}' already exists".format(v)
+                    assert not self.has_node(v),\
+                        "'{}' already exists".format(v)
                 else:
                     assert self.has_node(v), "'{}' does not exist".format(v)
         else:
@@ -141,19 +144,19 @@ class ReactionDiagram(nx.DiGraph):
         else:
             pass
 
-        if subgraph_name in self.subgraphs.keys():
+        if pathname in self.pathways.keys():
             # Build list of new subgraph.
-            new_sg = list(self.subgraphs[subgraph_name].nodes()).append(label)
+            new_sg = list(self.pathways[pathname].nodes()).append(label)
         else:
             new_sg = [label]
         # Assign subgraphs dictionary with updated subgraph.
-        self.subgraphs[subgraph_name] = self.subgraph(new_sg)
+        self.pathways[pathname] = self.subgraph(new_sg)
         return
 
     def prepare_diagram(self, step_size):
         self._step_size = step_size
-        for subgraph in self.subgraphs.keys():
-            for n, data in self.subgraphs[subgraph].nodes(data=True):
+        for pathway in self.pathways.keys():
+            for n, data in self.pathways[pathway].nodes(data=True):
                 pos = data['position']
                 line_coords = np.array([[pos, pos + self._step_size],
                                         [data['energy'], data['energy']]],

--- a/rxnpath/core.py
+++ b/rxnpath/core.py
@@ -176,7 +176,8 @@ class ReactionDiagram(nx.DiGraph):
                      fname=None, prefix=None, show_positions=False,
                      state_line_attr=dict(linewidth=3, linestyle='-'),
                      edge_line_attr=dict(linewidth=1, linestyle='--'),
-                     saveparams=dict(transparent=True),
+                     ylabel_fontsize=20, xlabel_fontsize=20,
+                     ytick_labelsize=16, saveparams=dict(transparent=True),
                      adjust=dict()):
         """
         Renders the reaction diagram.
@@ -213,6 +214,10 @@ class ReactionDiagram(nx.DiGraph):
         edge_line_attr : dict, optional
             Adjusts line style for edges.
             Kwargs of `matplotlib.axes.Axes.plot()`
+        ylabel_fontsize, xlabel_fontsize : int, optional
+            Fontsize of label. Default is 20.
+        ytick_labelsize : int, optional
+            Fontsize of y-tick labels. Default is 16.
         saveparams : dict, optional
             Default sets `transparent=True`.
             kwargs of `matplotlib.pyplot.savefig()`
@@ -279,13 +284,13 @@ class ReactionDiagram(nx.DiGraph):
                            labelbottom=False)
 
         if ylabel:
-            ax.tick_params(axis='y', labelsize=16)
-            ax.set_ylabel(ylabel, fontsize=20)
+            ax.tick_params(axis='y', labelsize=ytick_labelsize)
+            ax.set_ylabel(ylabel, fontsize=ylabel_fontsize)
         else:
             pass
 
         if xlabel:
-            ax.set_xlabel(xlabel, fontsize=20)
+            ax.set_xlabel(xlabel, fontsize=xlabel_fontsize)
         else:
             pass
 


### PR DESCRIPTION
This PR greatly reduces the use of the `self.subgraphs` attribute, and even renames it to `self.pathways` to be more consistent with the package theme. Now all necessary data are store in each of the nodes (or states) and edges and `self.pathways` only records the subgraphs themselves, i.e., `self.pathways['A']` will return a `networkx.DiGraph()`, which describes the subgraph, or pathway, of `'A'`.

A bug was also fixed and now pathways are preserved when using `add_state()` and only the new label is appended to that pathway, instead of all of the nodes.